### PR TITLE
Fix: Fixed DynamoDB schema and broadcast issues

### DIFF
--- a/src/config/redis.ts
+++ b/src/config/redis.ts
@@ -2,7 +2,7 @@ import { Redis } from "ioredis";
 import dotenv from "dotenv";
 dotenv.config();
 
-const redisHost = process.env.REDIS_ENDPOINT_ADDRESS || "redis";
+const redisHost = process.env.REDIS_ENDPOINT_ADDRESS || "localhost";
 const redisPort = parseInt(process.env.REDIS_ENDPOINT_PORT || "6379", 10);
 
 const redisConfig = {

--- a/src/handlers/queueHandler.ts
+++ b/src/handlers/queueHandler.ts
@@ -8,7 +8,7 @@ export const registerQueueHandlers = (io: Server, socket: Socket) => {
 
       handleSendMessageToQueue(channelName, message, createdAt);
 
-      io.to(channelName).emit(`message:receive:${channelName}`, {
+      socket.broadcast.to(channelName).emit(`message:receive:${channelName}`, {
         createdAt,
         content: message,
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,6 @@ const onConnection = (socket: Socket) => {
   registerPresenceHandlers(io, socket);
   registerDisconnection(socket);
 };
-console.log(process.env);
 io.use(authenticate);
 
 io.on("connection", (socket: Socket) => {

--- a/src/models/message.ts
+++ b/src/models/message.ts
@@ -19,7 +19,7 @@ const messageSchema = new dynamoose.Schema({
     },
   },
   content: {
-    type: String,
+    type: dynamoose.type.ANY,
     required: true,
   },
   createdAt: {


### PR DESCRIPTION
Users are not able to store anything in the contents field of DynamoDB. Before they could only store string data types. This will allow the users more flexibility.

Fixed a potential bug, where the user who broadcasted the message would also receive it as well. 

The Problem
In ourchat application, the mechanism for broadcasting messages works fine since it's expected that all participants, including the sender, will receive the message. However, in a real-time collaborative text editor, you need to ensure that updates are synchronized among all participants without causing duplication.

Scenario:

Sender: A user who makes changes to the document.
Receiver: The same user who is also a participant in the collaborative document.
When the sender makes an edit, the changes are broadcasted to all participants, including themselves. In a collaborative editor, this can lead to the same change being applied multiple times if not handled correctly.

Example of the Problem
Let's say a user types a new paragraph in the collaborative editor. This change needs to be broadcast to all participants. However, if the sender also receives their own update (which is typical in a chat app), the editor might end up applying the same change twice:

User A types "Hello" in the editor.
The editor sends this change to the server.
The server broadcasts the change to all participants, including User A.
User A's editor receives this change again and applies it.
If not handled correctly, User A's editor might apply the change twice, resulting in duplicated content.

The user could handle this on the client side, by providing a unique identifier to each message, and filter out messages that come from them. 
